### PR TITLE
Cake 3141 - track user actions 

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "babel-cli": "^6.26.0",
     "babel-loader": "^7.1.4",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-preact": "^1.1.0",
     "copy-webpack-plugin": "^4.5.1",

--- a/src/Tracker.js
+++ b/src/Tracker.js
@@ -1,0 +1,66 @@
+const TRACKING_BASE = 'https://beacon.wikia-services.com/__track/special/trackingevent';
+const TRACK_PARAMS = {
+    LANGUAGE_CODE: 'lc',
+    CATEGORY: 'ga_category',
+    ACTION: 'ga_action',
+    LABEL: 'ga_label',
+};
+const TRACK_TIMEOUT = 3000;
+
+class Tracker {
+    constructor(language, enable) {
+        this.enable = enable;
+        this.defaultParams = {
+            [TRACK_PARAMS.LANGUAGE_CODE]: language,
+        };
+    }
+
+    // largely taken from https://github.com/Wikia/app/blob/a34191d/resources/wikia/modules/tracker.js
+    track(category, action, label) {
+        if (!this.enable) {
+            return;
+        }
+
+        const container = document.head || document.getElementsByTagName( 'head' )[ 0 ] || document.documentElement;
+        const params = {
+            ...this.defaultParams,
+            [TRACK_PARAMS.CATEGORY]: category,
+            [TRACK_PARAMS.ACTION]: action,
+            [TRACK_PARAMS.LABEL]: label,
+        };
+        const requestParams = [];
+
+        for (const p in params) {
+            requestParams.push(`${encodeURIComponent(p)}=${encodeURIComponent(params[p])}`);
+        }
+
+        let script = document.createElement('script');
+        script.src = `${TRACKING_BASE}?${requestParams.join('&')}`;
+        if ('async' in script) {
+            script.async = true;
+        }
+
+        script.onload = script.onreadystatechange = function( abort ) {
+            if ( abort || !script.readyState || /loaded|complete/.test( script.readyState ) ) {
+                // Handle memory leak in IE
+                script.onload = script.onreadystatechange = null;
+
+                // Remove the script
+                if ( container && script.parentNode ) {
+                    container.removeChild( script );
+                }
+
+                script = undefined;
+            }
+        };
+
+        container.insertBefore(script, container.firstChild);
+        setTimeout(() => {
+            if (script) {
+                script.onload(true);
+            }
+        }, TRACK_TIMEOUT);
+    }
+}
+
+export default Tracker;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -6,38 +6,69 @@ const DIALOGS = {
     CONFIRM_REJECT: 'confirm-reject',
 };
 
+const TRACKING_CATEGORY = 'gdpr-modal';
+const ACTION_IMPRESSION = 'Impression';
+const ACTION_CLICK = 'Click';
+
 class App extends Component {
     state = {
         dialog: DIALOGS.INITIAL,
     };
 
-    onAccept = () => {
+    componentDidMount() {
+        this.track(ACTION_IMPRESSION, 'modal-view');
+    }
+
+    track(action, label) {
+        this.props.tracker.track(TRACKING_CATEGORY, action, label);
+    }
+
+    accept() {
         this.props.optInManager.setTrackingAccepted();
         this.props.onRequestAppRemove();
         this.props.options.onAcceptTracking();
-    };
+    }
 
-    onReject = () => {
+    reject() {
         this.props.optInManager.setTrackingRejected();
         this.props.onRequestAppRemove();
         this.props.options.onRejectTracking();
+    }
+
+    onInitialAccept = () => {
+        this.track(ACTION_CLICK, 'accept-screen-1');
+        this.accept();
+    };
+
+    onFallbackAccept = () => {
+        this.track(ACTION_CLICK, 'accept-screen-2');
+        this.accept();
     };
 
     onInitialReject = () => {
+        this.track(ACTION_CLICK, 'reject-screen-1');
         this.setState({ dialog: DIALOGS.CONFIRM_REJECT });
     };
 
+    onFallbackReject = () => {
+        this.track(ACTION_CLICK, 'reject-screen-2');
+        this.reject();
+    };
+
     render({ options }, { dialog }) {
+        let onAccept;
         let onReject;
         let bodyText;
 
         switch (dialog) {
             case DIALOGS.INITIAL:
+                onAccept = this.onInitialAccept;
                 onReject = this.onInitialReject;
                 bodyText = 'cookies?';
                 break;
             default:
-                onReject = this.onReject;
+                onAccept = this.onFallbackAccept;
+                onReject = this.onFallbackReject;
                 bodyText = 'Are you sure???';
                 break;
         }
@@ -54,7 +85,7 @@ class App extends Component {
                         {bodyText}
                     </div>
                     <div className={styles.footer}>
-                        <button onClick={this.onAccept}>
+                        <button onClick={onAccept}>
                             accept all cookies
                         </button>
                         <button onClick={onReject}>

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const defaultOptions = {
     country: null, // country code
     countriesRequiringPrompt: null, // array of lower case country codes
     language: null,
+    track: true,
     zIndex: 1000,
     onAcceptTracking() {
         console.log('user opted in to tracking');

--- a/src/index.js
+++ b/src/index.js
@@ -42,10 +42,10 @@ function removePrompt() {
 function runApp(AppComponent, appOptions) {
     const root = getAppRoot();
     const options = Object.assign({}, defaultOptions, appOptions);
-    const tracker = new Tracker('en', options.track); // TODO: use actual language once -3139 is done
+    const langManager = new LanguageManager(options.language);
+    const tracker = new Tracker(langManager.lang, options.track);
     const optInManager = new OptInManager(options.cookieName, options.cookieExpiration);
     const geoManager = new GeoManager(options.country, options.countriesRequiringPrompt);
-    const langManager = new LanguageManager(options.language);
     const contentManager = new ContentManager(langManager.lang);
 
     if (!geoManager.needsTrackingPrompt()) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import {h, render} from 'preact';
 import App from './components/App';
 import OptInManager from "./OptInManager";
 import GeoManager from "./GeoManager";
+import Tracker from './Tracker';
 
 let root = null;
 let hotOptions = null;
@@ -11,6 +12,7 @@ const defaultOptions = {
     country: null, // country code
     countriesRequiringPrompt: null, // array of lower case country codes
     language: null, // use browser language
+    track: true,
     zIndex: 1000,
     onAcceptTracking() {
         console.log('user opted in to tracking');
@@ -39,6 +41,7 @@ function removePrompt() {
 function runApp(AppComponent, appOptions) {
     const root = getAppRoot();
     const options = Object.assign({}, defaultOptions, appOptions);
+    const tracker = new Tracker('en', options.track); // TODO: use actual language once -3139 is done
     const optInManager = new OptInManager(options.cookieName, options.cookieExpiration);
     const geoManager = new GeoManager(options.country, options.countriesRequiringPrompt);
 
@@ -52,6 +55,7 @@ function runApp(AppComponent, appOptions) {
         render(
             <AppComponent
                 onRequestAppRemove={removePrompt}
+                tracker={tracker}
                 optInManager={optInManager}
                 options={options}
             />,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -104,6 +104,7 @@ module.exports = {
                         presets: ['env', 'preact'],
                         plugins: [
                             'transform-class-properties',
+                            'transform-object-rest-spread',
                         ]
                     }
                 }]

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,7 +806,7 @@ babel-plugin-transform-flow-strip-types@^6.8.0:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-object-rest-spread@^6.22.0:
+babel-plugin-transform-object-rest-spread@^6.22.0, babel-plugin-transform-object-rest-spread@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
   dependencies:


### PR DESCRIPTION
@Wikia/cake 

Tracks user actions when using the modal. Whether or not including the beacon is considered personably identifiable information is TBD. If it is the tracking implementation might change, but its usage and interface should remain the same.