### PR TITLE
update entry point to class

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": ["env", "preact"],
+  "plugins": [
+    "transform-class-properties",
+    "transform-object-rest-spread"
+  ]
+}

--- a/demo.html
+++ b/demo.html
@@ -12,7 +12,7 @@
 HERE IS MY PAGE
 
 <script type="text/javascript">
-    trackingOptIn.default({
+    var optIn = trackingOptIn.default({
         countriesRequiringPrompt: ['us'],
         country: 'us',
     });

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dev": "cross-env NODE_ENV=development webpack-serve ./webpack.config.js",
     "build": "yarn clean && yarn build:webpack && yarn build:babel",
     "build:webpack": "cross-env NODE_ENV=production webpack",
-    "build:babel": "babel src --out-dir dist",
+    "build:babel": "babel src --out-dir dist/src --ignore index-dev.js",
     "clean": "rimraf dist"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,11 @@
     "preact": "^8.2.9"
   },
   "scripts": {
-    "start": "cross-env NODE_ENV=development webpack-serve ./webpack.config.js",
-    "build": "cross-env NODE_ENV=production webpack",
+    "start": "yarn clean && yarn dev",
+    "dev": "cross-env NODE_ENV=development webpack-serve ./webpack.config.js",
+    "build": "yarn clean && yarn build:webpack && yarn build:babel",
+    "build:webpack": "cross-env NODE_ENV=production webpack",
+    "build:babel": "babel src --out-dir dist",
     "clean": "rimraf dist"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "start": "yarn clean && yarn dev",
     "dev": "cross-env NODE_ENV=development webpack-serve ./webpack.config.js",
-    "build": "yarn clean && yarn build:webpack && yarn build:babel",
+    "build": "yarn build:webpack",
     "build:webpack": "cross-env NODE_ENV=production webpack",
     "build:babel": "babel src --out-dir dist/src --ignore index-dev.js",
     "clean": "rimraf dist"

--- a/src/index-dev.js
+++ b/src/index-dev.js
@@ -1,6 +1,6 @@
 import main from './index';
 
-// handles the hot reloading so it doesn't get included in the babel build
+// this module handles the hot reloading so it doesn't get included in the babel build
 let appInstance = null;
 
 if (module.hot) {

--- a/src/index-dev.js
+++ b/src/index-dev.js
@@ -1,0 +1,17 @@
+import main from './index';
+
+// handles the hot reloading so it doesn't get included in the babel build
+let appInstance = null;
+
+if (module.hot) {
+    module.hot.accept(['./index'], () => {
+        appInstance.removeApp();
+        const newMain = require('./index').default;
+        appInstance = newMain(appInstance.options);
+    });
+}
+
+export default function devMain(options) {
+    appInstance = main(options);
+    return appInstance;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,15 @@ class TrackingOptIn {
         this.root = null;
     };
 
+    reset() {
+        this.clear();
+        this.render();
+    }
+
+    clear() {
+        this.optInManager.clear();
+    }
+
     render() {
         if (!this.root) {
             this.root = document.createElement('div');

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import OptInManager from "./OptInManager";
 import Tracker from "./Tracker";
 import ContentManager from "./ContentManager";
 import GeoManager from "./GeoManager";
-import {h, render} from "preact/dist/preact";
+import {h, render} from "preact";
 import App from "./components/App";
 
 const DEFAULT_OPTIONS = {

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,12 @@
-import {h, render} from 'preact';
-import ContentManager from './ContentManager';
-import LanguageManager from './LangManager';
-import App from './components/App';
+import LanguageManager from "./LangManager";
 import OptInManager from "./OptInManager";
+import Tracker from "./Tracker";
+import ContentManager from "./ContentManager";
 import GeoManager from "./GeoManager";
-import Tracker from './Tracker';
+import {h, render} from "preact/dist/preact";
+import App from "./components/App";
 
-let root = null;
-let hotOptions = null;
-const defaultOptions = {
+const DEFAULT_OPTIONS = {
     cookieName: null, // use default cookie name
     cookieExpiration: null, // use default
     country: null, // country code
@@ -24,62 +22,52 @@ const defaultOptions = {
     },
 };
 
-function getAppRoot() {
-    if (root !== null) {
-        return root;
+class TrackingOptIn {
+    constructor(options) {
+        this.options = Object.assign({}, DEFAULT_OPTIONS, options);
+        this.langManager = new LanguageManager(this.options.language);
+        this.tracker = new Tracker(this.langManager.lang, this.options.track);
+        this.optInManager = new OptInManager(this.options.cookieName, this.options.cookieExpiration);
+        this.geoManager = new GeoManager(this.options.country, this.options.countriesRequiringPrompt);
+        this.contentManager = new ContentManager(this.langManager.lang);
     }
 
-    root = document.createElement('div');
-    document.body.appendChild(root);
+    removeApp = () => {
+        render(null, this.root, this.root.lastChild);
+        this.root.parentNode.removeChild(this.root);
+        this.root = null;
+    };
 
-    return root;
-}
+    render() {
+        if (!this.root) {
+            this.root = document.createElement('div');
+            document.body.appendChild(this.root);
+        }
 
-function removePrompt() {
-    const root = getAppRoot();
-    render(null, root, root.lastChild);
-}
-
-function runApp(AppComponent, appOptions) {
-    const root = getAppRoot();
-    const options = Object.assign({}, defaultOptions, appOptions);
-    const langManager = new LanguageManager(options.language);
-    const tracker = new Tracker(langManager.lang, options.track);
-    const optInManager = new OptInManager(options.cookieName, options.cookieExpiration);
-    const geoManager = new GeoManager(options.country, options.countriesRequiringPrompt);
-    const contentManager = new ContentManager(langManager.lang);
-
-    if (!geoManager.needsTrackingPrompt()) {
-        options.onAcceptTracking();
-    } else if (optInManager.hasAcceptedTracking()) {
-        options.onAcceptTracking();
-    } else if (optInManager.hasRejectedTracking()) {
-        options.onRejectTracking();
-    } else {
-        render(
-            <AppComponent
-                onRequestAppRemove={removePrompt}
-                tracker={tracker}
-                optInManager={optInManager}
-                options={options}
-                content={contentManager.content}
-            />,
-            root,
-            root.lastChild
-        );
+        if (!this.geoManager.needsTrackingPrompt()) {
+            this.options.onAcceptTracking();
+        } else if (this.optInManager.hasAcceptedTracking()) {
+            this.options.onAcceptTracking();
+        } else if (this.optInManager.hasRejectedTracking()) {
+            this.options.onRejectTracking();
+        } else {
+            render(
+                <App
+                    onRequestAppRemove={this.removeApp}
+                    tracker={this.tracker}
+                    optInManager={this.optInManager}
+                    options={this.options}
+                    content={this.contentManager.content}
+                />,
+                this.root,
+                this.root.lastChild
+            );
+        }
     }
 }
 
-function trackingOptIn(options) {
-    hotOptions = options;
-    runApp(App, options);
+export default function main(options) {
+    const instance = new TrackingOptIn(options);
+    instance.render();
+    return instance;
 }
-
-if (module.hot) {
-    module.hot.accept(['./components/App'], () => {
-        const newApp = require('./components/App').default;
-        runApp(newApp, hotOptions);
-    });
-}
-
-export default trackingOptIn;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -98,16 +98,7 @@ module.exports = {
             {
                 test: /\.js$/,
                 include: `${__dirname}/src`,
-                use: [{
-                    loader: 'babel-loader',
-                    options: {
-                        presets: ['env', 'preact'],
-                        plugins: [
-                            'transform-class-properties',
-                            'transform-object-rest-spread',
-                        ]
-                    }
-                }]
+                use: 'babel-loader',
             },
             cssLoader,
         ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const autoprefixerPlugin = autoprefixer({
     browsers: browsers.join(', '),
 });
 
+let entry = './src/index.js';
 let topLevelOptions = {};
 let plugins = [];
 let cssLoader = {
@@ -47,12 +48,13 @@ let cssLoader = {
 };
 
 if (process.env.NODE_ENV === 'development') {
+    entry = './src/index-dev.js';
     topLevelOptions = {
         serve: {
-            host: '0.0.0.0',
+            host: 'localhost',
             port: 3000,
             hot: {
-                host: '0.0.0.0',
+                host: 'localhost',
                 port: 3001,
             }
         }
@@ -86,7 +88,7 @@ if (process.env.NODE_ENV === 'development') {
 
 module.exports = {
     mode: process.env.NODE_ENV,
-    entry: './src/index.js',
+    entry,
     output: {
         path: buildPath,
         filename: 'tracking-opt-in.js',


### PR DESCRIPTION
@Wikia/cake 

Updates the main entry point to use a class and returns an instance of that class when instantiated. This will make [-3132](https://wikia-inc.atlassian.net/browse/CAKE-3132) easier since the app can just call `.reset()` rather than having to know the name of the cookie externally and re-initializing possibly without knowing the passed `options`. This might also make testing easier.

I also moved all the hot reloading logic to `index-dev` which isn't used when making the production build. This is removed by webpack but initially I wanted to also expose all functionality as es5 modules in addition to making the entry point a class, but I ran into an issue where `styles.scss` was getting ignored in the babel transpilation, similar to what @drsnyder is seeing with unit tests. Hopefully the fix is the same, and once that's figured out I'll re-add the es5 modules as part of the build.