### PR TITLE
Styles in script

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -1,8 +1,7 @@
 <html>
 <head>
     <!-- for build testing, uncomment these -->
-    <!--<link rel="stylesheet" href="dist/styles.css">-->
-    <!--<script src="dist/tracking-opt-in.js"></script>-->
+    <!-- <script src="dist/tracking-opt-in.js"></script> -->
 
     <!-- for dev testing, uncomment this -->
     <script src="/tracking-opt-in.js"></script>

--- a/package.json
+++ b/package.json
@@ -15,16 +15,17 @@
     "copy-webpack-plugin": "^4.5.1",
     "cross-env": "^5.1.4",
     "css-loader": "^0.28.11",
+    "js-cookie": "^2.2.0",
     "jsdom": "^11.10.0",
     "karma": "^2.0.2",
     "karma-coverage": "^1.1.2",
     "karma-jsdom-launcher": "^6.1.3",
     "karma-mocha": "^1.3.0",
     "karma-webpack": "^3.0.0",
-    "mini-css-extract-plugin": "^0.4.0",
     "mocha": "^5.1.1",
     "node-sass": "^4.9.0",
     "postcss-loader": "^2.1.4",
+    "preact": "^8.2.9",
     "rimraf": "^2.6.2",
     "sass-loader": "^7.0.1",
     "style-loader": "^0.21.0",
@@ -33,8 +34,6 @@
     "webpack-serve": "^0.3.2"
   },
   "dependencies": {
-    "js-cookie": "^2.2.0",
-    "preact": "^8.2.9"
   },
   "scripts": {
     "start": "yarn clean && yarn dev",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,3 @@
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const autoprefixer = require('autoprefixer');
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,40 +15,12 @@ const autoprefixerPlugin = autoprefixer({
     cascade: false,
     browsers: browsers.join(', '),
 });
+const isDevevelopment = process.env.NODE_ENV === 'development';
 
-let entry = './src/index.js';
 let topLevelOptions = {};
 let plugins = [];
-let cssLoader = {
-    test: /\.s?css$/,
-    use: [
-        {
-            loader: 'css-loader',
-            options: {
-                sourceMap: false,
-                modules: true,
-            },
-        },
-        {
-            loader: 'postcss-loader',
-            options: {
-                sourceMap: false,
-                plugins: () => [
-                    autoprefixerPlugin,
-                ],
-            },
-        },
-        {
-            loader: 'sass-loader',
-            options: {
-                sourceMap: false
-            },
-        }
-    ],
-};
 
 if (process.env.NODE_ENV === 'development') {
-    entry = './src/index-dev.js';
     topLevelOptions = {
         serve: {
             host: 'localhost',
@@ -66,29 +38,11 @@ if (process.env.NODE_ENV === 'development') {
             to: `${buildPath}/index.html`,
         }])
     ];
-
-    cssLoader.use[0].options.sourceMap = true;
-    cssLoader.use[1].options.sourceMap = true;
-    cssLoader.use[2].options.sourceMap = true;
-    cssLoader.use.unshift({
-        loader: 'style-loader',
-        options: {
-            sourceMap: true,
-        }
-    });
-} else {
-    cssLoader.use.unshift(MiniCssExtractPlugin.loader);
-    plugins = [
-        ...plugins,
-        new MiniCssExtractPlugin({
-            filename: 'styles.css',
-        })
-    ]
 }
 
 module.exports = {
     mode: process.env.NODE_ENV,
-    entry,
+    entry: isDevevelopment ? './src/index.js' : './src/index-dev.js',
     output: {
         path: buildPath,
         filename: 'tracking-opt-in.js',
@@ -102,7 +56,39 @@ module.exports = {
                 include: `${__dirname}/src`,
                 use: 'babel-loader',
             },
-            cssLoader,
+            {
+                test: /\.s?css$/,
+                use: [
+                    {
+                        loader: 'style-loader',
+                        options: {
+                            sourceMap: isDevevelopment,
+                        },
+                    },
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            sourceMap: isDevevelopment,
+                            modules: true,
+                        },
+                    },
+                    {
+                        loader: 'postcss-loader',
+                        options: {
+                            sourceMap: isDevevelopment,
+                            plugins: () => [
+                                autoprefixerPlugin,
+                            ],
+                        },
+                    },
+                    {
+                        loader: 'sass-loader',
+                        options: {
+                            sourceMap: isDevevelopment
+                        },
+                    }
+                ],
+            },
         ],
     },
     plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4884,13 +4884,6 @@ mimic-response@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
 
-mini-css-extract-plugin@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.0.tgz#ff3bf08bee96e618e177c16ca6131bfecef707f9"
-  dependencies:
-    loader-utils "^1.1.0"
-    webpack-sources "^1.1.0"
-
 minimalistic-assert@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"


### PR DESCRIPTION
- always put styles in the script (clean-up the webpack config BTW)
- `dist` version does not need anything (`js-cookie` and `preact` are, in fact, dev dependencies)
- remove obsolete `mini-css-extract-plugin` package

/cc @Wikia/cake 