### PR TITLE
Remove the manual checkout from the jenkins pipeline script

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prepublishOnly": "yarn build",
     "test": "karma start",
     "test:watch": "karma start --auto-watch --no-single-run",
-    "test:selenium": "wdio webdriver.conf.js"
+    "test:selenium": "wdio webdriver.conf.js",
+    "validate-jenkins": "sh release/scripts/validate-jenkins-files.sh"
   }
 }

--- a/release/jenkins
+++ b/release/jenkins
@@ -1,28 +1,12 @@
-def buildimage = 'artifactory.wikia-inc.com/ops/k8s-deployer:0.0.12'
-
 pipeline {
   agent any
   tools { nodejs "v9.9.0" }
 
   stages {
-    stage('Git Checkout') {
-      steps {
-        checkout([$class: 'GitSCM',
-            doGenerateSubmoduleConfigurations: false,
-            extensions: [
-              [$class: 'RelativeTargetDirectory', relativeTargetDir: 'src/tracking-opt-in'],
-              [$class: 'LocalBranch', localBranch: "${params.branch}"],
-              [$class: 'CleanCheckout']
-            ],
-            submoduleCfg: [],
-            branches: [[name: "*/${params.branch}"]],
-            userRemoteConfigs: [[url: 'https://github.com/Wikia/tracking-opt-in.git']]])
-      }
-    }
 
     stage('Run the tests') {
       steps {
-        sh "cd src/tracking-opt-in && yarn install --frozen-lockfile && yarn test"
+        sh "yarn install --frozen-lockfile && yarn test"
       }
     }
 
@@ -40,7 +24,7 @@ pipeline {
 
     stage('Creating tag and releasing to npm') {
       steps {
-        sh "echo '...cerating tag and releasing to npm...'"
+        sh "echo '...creating tag and releasing to npm...'"
       }
     }
   }

--- a/release/scripts/validate-jenkins-files.sh
+++ b/release/scripts/validate-jenkins-files.sh
@@ -1,2 +1,7 @@
 #!/bin/bash
-curl -X POST  -F "jenkinsfile=<release/jenkins" http://jenkins.wikia-prod:8080/pipeline-model-converter/validate
+if [[ -z $JENKINS_URL ]]; then
+    echo "Unable to validate with a \$JENKINS_URL environment variable."
+    exit 1
+fi
+
+curl -X POST  -F "jenkinsfile=<release/jenkins" $JENKINS_URL/pipeline-model-converter/validate

--- a/release/scripts/validate-jenkins-files.sh
+++ b/release/scripts/validate-jenkins-files.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl -X POST  -F "jenkinsfile=<release/jenkins" http://jenkins.wikia-prod:8080/pipeline-model-converter/validate


### PR DESCRIPTION
After taking a closer look at the jenkins UI (it's a maze) I noticed there were additional options that could be provided to the initial SCM checkout. In those options you can specify that you want the repo to be cleaned before and after the checkout. That should ensure a pristine repo so we can remove the redundant internal checkout.

I must have been so excited to get the deploy working in the FC that I overlooked this option. If it works as expected here we can update that workflow as well.

As part of this, I also added tooling to validate the jenkins file. Having to commit, push, go to jenkins, rebuild, repeat slows down the iteration on building the release pipeline. This should help improve that process by giving the developer a local means for validating the file without having to go through the steps above. To validate, run `yarn validate-jenkins`.

@Wikia/cake 