### PR TITLE
param to prevent scroll while the dialog is shown

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -10,7 +10,45 @@
 </head>
 <body>
 
-HERE IS MY PAGE
+<p>Lorem ipsum dolor amet pug marfa pitchfork 90's raclette. Flannel succulents art party XOXO vexillologist hammock tumeric hexagon chicharrones pok pok skateboard. Cliche irony cloud bread, distillery church-key shoreditch crucifix you probably haven't heard of them drinking vinegar. Ugh bicycle rights squid, poutine vaporware chicharrones edison bulb. Roof party yuccie forage single-origin coffee, brooklyn actually beard etsy schlitz.</p>
+
+<p>Irony normcore cray, fanny pack raclette forage venmo flexitarian chia helvetica VHS. Hella small batch synth vegan cold-pressed lumbersexual, waistcoat chicharrones intelligentsia 8-bit flannel. Waistcoat cardigan viral, bitters shabby chic pour-over tofu master cleanse austin scenester knausgaard farm-to-table cred palo santo literally. Woke snackwave try-hard organic four loko, next level gentrify beard. Tumblr YOLO drinking vinegar selfies photo booth hoodie fam. Plaid next level man braid, banh mi scenester chillwave forage authentic echo park aesthetic selvage letterpress occupy.</p>
+
+<p>Shabby chic plaid fam blog farm-to-table snackwave brooklyn chillwave stumptown semiotics 8-bit. Mixtape shabby chic fam vaporware pork belly letterpress. Vinyl pinterest squid, +1 selvage edison bulb taiyaki skateboard hoodie dreamcatcher tattooed hashtag. Pour-over poutine umami sartorial. Waistcoat truffaut intelligentsia, DIY activated charcoal tilde authentic blue bottle irony cardigan cray before they sold out small batch.</p>
+
+<p>Hammock letterpress paleo meggings, selfies literally portland coloring book. Chillwave ugh intelligentsia selfies ramps narwhal. Forage coloring book fanny pack pok pok, slow-carb 90's tumeric gluten-free. You probably haven't heard of them hammock selvage typewriter hashtag church-key, fingerstache glossier banh mi direct trade brooklyn 8-bit vexillologist. Gentrify direct trade gluten-free tattooed. Lyft tote bag iPhone echo park bushwick shaman small batch. Tattooed bushwick everyday carry paleo, williamsburg readymade migas.</p>
+
+<p>Iceland jianbing palo santo kickstarter meh slow-carb, mustache tofu. Succulents messenger bag beard hoodie humblebrag brooklyn. Portland post-ironic locavore, microdosing shabby chic cray occupy thundercats raw denim truffaut. Fam tousled pok pok locavore.</p>
+
+<p>Lorem ipsum dolor amet gluten-free enamel pin DIY raw denim artisan cred. Raclette cardigan poutine jean shorts selvage la croix organic. Sustainable dreamcatcher pinterest scenester hella, gochujang synth lomo readymade banjo fam. Cronut cardigan kombucha try-hard banjo listicle iceland thundercats semiotics. La croix kombucha mixtape pinterest thundercats, echo park hot chicken adaptogen salvia lo-fi butcher blue bottle put a bird on it.</p>
+
+<p>Palo santo occupy try-hard ethical humblebrag flexitarian. Paleo yr migas glossier deep v prism ethical. Shabby chic gochujang godard, raw denim knausgaard fanny pack health goth lo-fi farm-to-table literally bicycle rights flannel. Activated charcoal salvia chambray, adaptogen fanny pack lomo +1 literally shabby chic. Tote bag cronut lomo forage.</p>
+
+<p>Butcher beard lyft tote bag, iPhone health goth sustainable bicycle rights waistcoat raclette vexillologist. DIY health goth bushwick organic hoodie taxidermy yr lyft fanny pack normcore lomo. Fixie tumblr sriracha green juice, sustainable cardigan brunch pabst quinoa portland helvetica salvia. Actually succulents flannel salvia, sartorial wayfarers schlitz jianbing. Hot chicken sriracha lumbersexual lomo butcher. Lomo YOLO brooklyn, yr kombucha vexillologist poutine helvetica VHS seitan jean shorts 8-bit. Whatever af migas vegan wayfarers pour-over.</p>
+
+<p>Pinterest vape pour-over mustache glossier humblebrag. Poutine organic kale chips locavore succulents kitsch disrupt ugh lyft cred unicorn selfies meggings. Thundercats bicycle rights occupy, subway tile mixtape biodiesel migas venmo before they sold out taxidermy. Try-hard crucifix tousled, knausgaard cloud bread migas ethical vexillologist taiyaki authentic kogi. Butcher selvage bespoke next level, franzen 8-bit truffaut farm-to-table synth austin. Etsy fashion axe 90's, lomo waistcoat selfies activated charcoal heirloom hoodie pork belly skateboard unicorn. Lumbersexual brooklyn marfa hell of ethical locavore ennui truffaut unicorn literally beard sustainable vaporware chartreuse plaid.</p>
+
+<p>Gentrify vinyl health goth thundercats. Asymmetrical truffaut ennui, +1 cold-pressed etsy XOXO schlitz next level tacos enamel pin hell of. Keytar neutra you probably haven't heard of them vexillologist occupy mixtape kogi plaid bushwick gochujang pour-over cronut. Woke beard tacos portland wayfarers williamsburg, ethical listicle lo-fi taxidermy fam mixtape scenester hammock photo booth. Shabby chic vaporware trust fund franzen vice pop-up thundercats helvetica tattooed bicycle rights humblebrag readymade.</p>
+
+<p>Shoreditch mlkshk beard, try-hard enamel pin fam locavore tofu ramps. Affogato DIY 3 wolf moon echo park salvia. 90's affogato gentrify roof party glossier. Enamel pin mustache crucifix, sustainable disrupt iceland blue bottle godard XOXO hot chicken lumbersexual iPhone edison bulb.</p>
+
+<p>Health goth ethical meggings bicycle rights, roof party yr viral umami chartreuse fam sartorial subway tile before they sold out messenger bag taiyaki. Prism wayfarers shoreditch austin. Photo booth beard flexitarian wayfarers, lyft echo park irony locavore tofu synth mumblecore. Tilde gentrify plaid freegan. Lumbersexual microdosing chicharrones, mlkshk cronut lo-fi crucifix chambray ugh selvage pickled bitters freegan.</p>
+
+<p>Mixtape etsy before they sold out semiotics tofu salvia, PBR&B offal four dollar toast paleo 3 wolf moon mumblecore portland jianbing leggings. Artisan put a bird on it pok pok before they sold out shoreditch readymade brunch viral drinking vinegar. Aesthetic venmo food truck you probably haven't heard of them PBR&B pop-up gentrify. Kombucha kogi tousled meh, jianbing wayfarers hashtag. Retro palo santo sriracha tote bag art party copper mug flexitarian cardigan microdosing salvia ramps.</p>
+
+<p>Seitan four dollar toast bicycle rights, brunch paleo bushwick enamel pin 90's chambray marfa affogato keytar tumblr blog. Leggings sriracha single-origin coffee, banh mi 3 wolf moon enamel pin farm-to-table pinterest irony. Schlitz banh mi subway tile messenger bag chicharrones chartreuse ennui affogato portland four dollar toast. Microdosing direct trade deep v scenester cronut fashion axe adaptogen. Mixtape fanny pack 90's chillwave. Hot chicken forage man braid offal 3 wolf moon, tousled cold-pressed.</p>
+
+<p>Copper mug kinfolk dreamcatcher hexagon gentrify shaman disrupt. Activated charcoal sartorial slow-carb chartreuse succulents poke copper mug fingerstache tbh vape. Meggings lomo small batch swag direct trade. Ethical umami vegan everyday carry, skateboard taiyaki hella snackwave poutine tacos selvage lo-fi. Lyft 3 wolf moon hexagon heirloom hot chicken, echo park ugh etsy street art gentrify copper mug subway tile poutine selvage. Crucifix cred hammock health goth meggings vegan green juice YOLO.</p>
+
+<p>Meditation pop-up heirloom celiac, tilde af flannel. Raclette cardigan flannel activated charcoal tacos schlitz. Chicharrones poke mlkshk jianbing, scenester jean shorts shaman live-edge. Listicle locavore umami live-edge. Copper mug salvia bitters sartorial cliche fanny pack raw denim ugh gochujang leggings.</p>
+
+<p>Cardigan lo-fi pork belly you probably haven't heard of them pok pok adaptogen authentic shoreditch sustainable chartreuse gluten-free fingerstache migas put a bird on it. Taxidermy you probably haven't heard of them kitsch, gastropub authentic jean shorts mustache selvage air plant keytar lumbersexual. Poutine YOLO lumbersexual, meggings kale chips narwhal pok pok banh mi VHS vexillologist pinterest truffaut gluten-free heirloom. Aesthetic stumptown tilde echo park gochujang.</p>
+
+<p>Semiotics retro disrupt hammock, irony tumeric gochujang offal DIY everyday carry. +1 raclette fashion axe tote bag microdosing. Direct trade chambray ramps gluten-free pitchfork seitan hoodie portland sriracha next level aesthetic messenger bag. Cred freegan gluten-free, af XOXO mustache lumbersexual tilde copper mug succulents bicycle rights artisan mumblecore. Photo booth ramps meggings enamel pin paleo before they sold out.</p>
+
+<p>Paleo pork belly scenester, twee bicycle rights VHS authentic food truck. Ramps put a bird on it squid bitters enamel pin next level you probably haven't heard of them. Bicycle rights neutra raclette poutine woke. Organic twee snackwave salvia subway tile, butcher normcore brooklyn semiotics four dollar toast mixtape banh mi pop-up tacos.</p>
+
+<p>Gastropub stumptown heirloom twee seitan, tbh +1 ethical celiac DIY fam meditation asymmetrical. Kitsch +1 poutine freegan sriracha knausgaard direct trade. Beard bitters microdosing tumeric plaid gochujang shoreditch deep v asymmetrical humblebrag venmo. Ennui tattooed XOXO pug mixtape air plant. Messenger bag cred master cleanse flannel vexillologist bitters. Flexitarian small batch raclette seitan.</p>
 
 <script type="text/javascript">
     var optIn = trackingOptIn.default({

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,11 +1,6 @@
 import {h, Component} from 'preact';
 import styles from './styles.scss';
 
-const DIALOGS = {
-    INITIAL: 'initial',
-    CONFIRM_REJECT: 'confirm-reject',
-};
-
 const TRACKING_CATEGORY = 'gdpr-modal';
 const ACTION_IMPRESSION = 'Impression';
 const ACTION_CLICK = 'Click';
@@ -13,6 +8,35 @@ const ACTION_CLICK = 'Click';
 class App extends Component {
     componentDidMount() {
         this.track(ACTION_IMPRESSION, 'modal-view');
+        this.preventScroll();
+    }
+
+    componentWillUnmount() {
+        this.enableScroll();
+    }
+
+    preventScroll() {
+        const scrollContainer = this.getScrollContainer();
+        if (scrollContainer) {
+            scrollContainer.classList.add(styles.withTrackingOptInDialogShown);
+        }
+    }
+
+    enableScroll() {
+        const scrollContainer = this.getScrollContainer();
+        if (scrollContainer) {
+            scrollContainer.classList.remove(styles.withTrackingOptInDialogShown);
+        }
+    }
+
+    getScrollContainer() {
+        if (!this.props.options.preventScrollOn) {
+            return null;
+        }
+
+        return typeof this.props.options.preventScrollOn === 'string' ?
+               document.querySelector(this.props.options.preventScrollOn) :
+               this.props.options.preventScrollOn;
     }
 
     track(action, label) {

--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -2,6 +2,10 @@ $breakpoint: 768px;
 $mobile-devices: "only screen and (max-width: #{$breakpoint - 1})";
 $desktop-devices: "only screen and (min-width: #{$breakpoint})";
 
+.withTrackingOptInDialogShown {
+  overflow: hidden;
+}
+
 .overlay {
   align-items: center;
   background-color: rgba(0, 0, 0, .5);

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const DEFAULT_OPTIONS = {
     country: null, // country code
     countriesRequiringPrompt: null, // array of lower case country codes
     language: null,
+    preventScrollOn: 'body',
     track: true,
     zIndex: 1000,
     onAcceptTracking() {
@@ -92,7 +93,13 @@ class TrackingOptIn {
 }
 
 export default function main(options) {
-    const { zIndex, onAcceptTracking, onRejectTracking, ...depOptions } = Object.assign({}, DEFAULT_OPTIONS, options);
+    const {
+        zIndex,
+        onAcceptTracking,
+        onRejectTracking,
+        preventScrollOn,
+        ...depOptions
+    } = Object.assign({}, DEFAULT_OPTIONS, options);
     const langManager = new LanguageManager(depOptions.language);
     const tracker = new Tracker(langManager.lang, depOptions.track);
     const optInManager = new OptInManager(depOptions.cookieName, depOptions.cookieExpiration);
@@ -105,6 +112,7 @@ export default function main(options) {
         geoManager,
         contentManager,
         {
+            preventScrollOn,
             zIndex,
             onAcceptTracking,
             onRejectTracking,


### PR DESCRIPTION
@Wikia/cake 
Prevents scrolling while the opt-in dialog is shown. According to caniuse.com both [`querySelector`](https://caniuse.com/#search=queryselector) and [`classList`](https://caniuse.com/#search=classlist) work on our [supported browsers](http://community.wikia.com/wiki/Help%3ASupported_browsers).