### PR TITLE
CAKE-3168 | Add query param override

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following options are accepted:
 - `countriesRequiringPrompt` - array of country codes that require tracking opt-in. See [`GeoManager`](https://github.com/Wikia/tracking-opt-in/blob/master/src/GeoManager.js) for the defaults.
 - `language` - Override the language used to display the dialog text. Defaults to `window.navigator.language` if available, otherwise to `en`.
 - `preventScrollOn` - Prevent scrolling on the specified element when the dialog is shown. Can be either an element or query selector passed to `document.querySelector`. Defaults to `'body'`, set to `null` to prevent this behavior.
+- `queryParam` - The name of the query param to forcefully set the accepted status. Defaults to `tracking-opt-in-accepted`
 - `track` - whether to track impressions and user consent/rejections. Defaults to `true`.
 - `zIndex` - Useful if elements on the app are appearing above the overlay/modal. Defaults to `1000`.
 - `onAcceptTracking` - The callback fired when:

--- a/src/OptInManager.js
+++ b/src/OptInManager.js
@@ -1,6 +1,7 @@
 import Cookies from 'js-cookie';
 
 const DEFAULT_ACCEPT_COOKIE_EXPIRATION = 18250; // 50 years in days
+const DEFAULT_QUERY_PARAM_NAME = 'tracking-opt-in-accepted';
 export const DEFAULT_COOKIE_NAME = 'tracking-opt-in-status';
 export const STATUS = {
     ACCEPTED: 'accepted',
@@ -17,13 +18,20 @@ function getCookieDomain() {
 }
 
 class OptInManager {
-    constructor(cookieName, expirationInDays, domain) {
+    constructor(cookieName, expirationInDays, queryParam) {
         this.cookieName = cookieName || DEFAULT_COOKIE_NAME;
         this.expirationInDays = expirationInDays || DEFAULT_ACCEPT_COOKIE_EXPIRATION;
-        this.domain = domain || getCookieDomain();
+        this.domain = getCookieDomain();
+        this.queryParam = queryParam || DEFAULT_QUERY_PARAM_NAME;
     }
 
     getValue() {
+        const cookie = Cookies.get(this.cookieName);
+
+        if (cookie === undefined && window.location.search.indexOf(this.queryParam) !== -1) {
+            this.setTrackingAccepted();
+        }
+
         return Cookies.get(this.cookieName);
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const DEFAULT_OPTIONS = {
     country: null, // country code
     countriesRequiringPrompt: null, // array of lower case country codes
     language: null,
+    queryParamName: null,
     preventScrollOn: 'body',
     track: true,
     zIndex: 1000,
@@ -102,7 +103,7 @@ export default function main(options) {
     } = Object.assign({}, DEFAULT_OPTIONS, options);
     const langManager = new LanguageManager(depOptions.language);
     const tracker = new Tracker(langManager.lang, depOptions.track);
-    const optInManager = new OptInManager(depOptions.cookieName, depOptions.cookieExpiration);
+    const optInManager = new OptInManager(depOptions.cookieName, depOptions.cookieExpiration, depOptions.queryParam);
     const geoManager = new GeoManager(depOptions.country, depOptions.countriesRequiringPrompt);
     const contentManager = new ContentManager(langManager.lang);
 


### PR DESCRIPTION
Adds the ability to override the cookie check with a query param `tracking-opt-in-accepted (default). If the query param is in `window.location.search` it will set the cookie for you. 

@Wikia/cake 