### PR TITLE
CAKE-3172 | Whitelist prod privacy and partner pages

### DIFF
--- a/src/TrackingOptIn-test.js
+++ b/src/TrackingOptIn-test.js
@@ -36,7 +36,7 @@ describe('TrackingOptIn', () => {
             onRejectTracking,
         };
 
-        trackingOptIn = new TrackingOptIn(tracker, optInManager, geoManager, contentManager, options);
+        trackingOptIn = new TrackingOptIn(tracker, optInManager, geoManager, contentManager, options, window.location);
     });
 
     afterEach(() => {
@@ -122,5 +122,8 @@ describe('TrackingOptIn', () => {
 
         trackingOptIn.render();
         assert.isNotOk(modalIsShown());
+
+        trackingOptIn.reset();
+        assert.isOk(modalIsShown());
     })
 });

--- a/src/TrackingOptIn-test.js
+++ b/src/TrackingOptIn-test.js
@@ -17,6 +17,7 @@ describe('TrackingOptIn', () => {
     let contentManager;
     let onAcceptTracking;
     let onRejectTracking;
+    let options;
 
     function modalIsShown() {
         return document.querySelector(`.${styles.overlay}`);
@@ -30,7 +31,7 @@ describe('TrackingOptIn', () => {
         onAcceptTracking = stub();
         onRejectTracking = stub();
 
-        const options = {
+        options = {
             onAcceptTracking,
             onRejectTracking,
         };
@@ -100,4 +101,26 @@ describe('TrackingOptIn', () => {
         trackingOptIn.reset();
         assert.isOk(modalIsShown());
     });
+
+    it('does not display on fandom.wikia.com/partner-list', () => {
+        trackingOptIn = new TrackingOptIn(tracker, optInManager, geoManager, contentManager, options, {host: 'fandom.wikia.com', pathname: '/partner-list'});
+        geoManager.needsTrackingPrompt.withArgs().returns(true);
+        geoManager.hasGeoCookie.withArgs().returns(true);
+        optInManager.hasAcceptedTracking.withArgs().returns(false);
+        optInManager.hasRejectedTracking.withArgs().returns(false);
+
+        trackingOptIn.render();
+        assert.isNotOk(modalIsShown());
+    });
+
+    it('does not display on http://www.wikia.com/Privacy_Policy', () => {
+        trackingOptIn = new TrackingOptIn(tracker, optInManager, geoManager, contentManager, options, {host: 'www.wikia.com', pathname: '/Privacy_Policy'});
+        geoManager.needsTrackingPrompt.withArgs().returns(true);
+        geoManager.hasGeoCookie.withArgs().returns(true);
+        optInManager.hasAcceptedTracking.withArgs().returns(false);
+        optInManager.hasRejectedTracking.withArgs().returns(false);
+
+        trackingOptIn.render();
+        assert.isNotOk(modalIsShown());
+    })
 });

--- a/src/TrackingOptIn-test.js
+++ b/src/TrackingOptIn-test.js
@@ -111,6 +111,9 @@ describe('TrackingOptIn', () => {
 
         trackingOptIn.render();
         assert.isNotOk(modalIsShown());
+
+        trackingOptIn.reset();
+        assert.isOk(modalIsShown());
     });
 
     it('does not display on http://www.wikia.com/Privacy_Policy', () => {

--- a/src/TrackingOptIn.js
+++ b/src/TrackingOptIn.js
@@ -1,13 +1,15 @@
 import {h, render} from "preact/dist/preact";
 import App from "./components/App";
+import {parseUrl} from "./urlUtils";
 
 class TrackingOptIn {
-    constructor(tracker, optInManager, geoManager, contentManager, options) {
+    constructor(tracker, optInManager, geoManager, contentManager, options, location) {
         this.tracker = tracker;
         this.optInManager = optInManager;
         this.geoManager = geoManager;
         this.contentManager = contentManager;
         this.options = options;
+        this.location = location || window.location;
     }
 
     removeApp = () => {
@@ -27,9 +29,26 @@ class TrackingOptIn {
             return false;
         } else if(!this.geoManager.hasGeoCookie()) {
             return false;
+        } else if(this.isOnWhiteListedPage()) {
+            return false;
         }
 
         return undefined;
+    }
+
+    isOnWhiteListedPage() {
+        const {host, pathname} = this.location;
+        const {privacyLink, partnerLink} = this.contentManager.content;
+        const privacyParsedUrl = parseUrl(privacyLink);
+        const partnerParsedUrl = parseUrl(partnerLink);
+
+        if (privacyParsedUrl.hostname === host && pathname === privacyParsedUrl.pathname) {
+            return true;
+        } else if (partnerParsedUrl.hostname === host && pathname === partnerParsedUrl.pathname) {
+            return true;
+        }
+
+        return false;
     }
 
     geoRequiresTrackingConsent() {

--- a/src/TrackingOptIn.js
+++ b/src/TrackingOptIn.js
@@ -9,7 +9,8 @@ class TrackingOptIn {
         this.geoManager = geoManager;
         this.contentManager = contentManager;
         this.options = options;
-        this.location = location || window.location;
+        this.location = location;
+        this.isReset = false;
     }
 
     removeApp = () => {
@@ -21,7 +22,9 @@ class TrackingOptIn {
     };
 
     hasUserConsented() {
-        if (!this.geoRequiresTrackingConsent()) {
+        if (this.isOnWhiteListedPage()) {
+            return false;
+        } else if (!this.geoRequiresTrackingConsent()) {
             return true;
         } else if (this.optInManager.hasAcceptedTracking()) {
             return true;
@@ -29,14 +32,16 @@ class TrackingOptIn {
             return false;
         } else if(!this.geoManager.hasGeoCookie()) {
             return false;
-        } else if(this.isOnWhiteListedPage()) {
-            return false;
         }
 
         return undefined;
     }
 
     isOnWhiteListedPage() {
+        if (this.isReset) {
+            return false;
+        }
+
         const {host, pathname} = this.location;
         const {privacyLink, partnerLink} = this.contentManager.content;
         const privacyParsedUrl = parseUrl(privacyLink);
@@ -56,6 +61,7 @@ class TrackingOptIn {
     }
 
     reset() {
+        this.isReset = true;
         this.clear();
         this.render();
     }

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,8 @@ export default function main(options) {
             zIndex,
             onAcceptTracking,
             onRejectTracking,
-        }
+        },
+        window.location,
     );
     instance.render();
     return instance;

--- a/src/urlUtils.js
+++ b/src/urlUtils.js
@@ -1,0 +1,5 @@
+export function parseUrl(url) {
+    const parser = document.createElement('a');
+    parser.href = url;
+    return parser;
+}


### PR DESCRIPTION
Whitelists the `privacyLink` and `partnerLink` from the content manager. Not sure how to write a selenium test for this until it's actually live on those pages. 

@Wikia/cake 