### PR TITLE
rejection expiration time

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Invocation of the exported function returns an instance of `TrackingOptIn`. See 
 The following options are accepted:
 - `beaconCookieName` - The name of the beacon cookie that'll be added to tracking calls
 - `cookieName` - The name of the cookie used for the user's tracking consent status. Should only be changed for development purposes. defaults to `tracking-opt-in-status`.
-- `cookieExpiration` - How long the cookie should last when the user accepts consent. Defaults to 50 years.
+- `cookieExpiration` - How long the consent cookie should last when the user accepts consent. Defaults to 50 years.
+- `cookieRejectExpiration` - How long the reject cookie should last when the user rejects. Defaults to 1 days.
 - `country` - Override the country code for determining the country the user is visiting from. Defaults to reading from the `Geo` cookie that should be available in all of our web apps.
 - `countriesRequiringPrompt` - array of country codes that require tracking opt-in. See [`GeoManager`](https://github.com/Wikia/tracking-opt-in/blob/master/src/GeoManager.js) for the defaults.
 - `language` - Override the language used to display the dialog text. Defaults to `window.navigator.language` if available, otherwise to `en`.

--- a/src/OptInManager-test.js
+++ b/src/OptInManager-test.js
@@ -12,9 +12,10 @@ describe('OptInManager', () => {
         const customExpiration = 2;
         const customQueryParam = 'my-param';
 
-        const optInManager = new OptInManager('www.test.com', customCookieName, customExpiration, customQueryParam);
+        const optInManager = new OptInManager('www.test.com', customCookieName, customExpiration, customExpiration, customQueryParam);
         assert.equal(optInManager.cookieName, customCookieName);
-        assert.equal(optInManager.expirationInDays, customExpiration);
+        assert.equal(optInManager.acceptExpiration, customExpiration);
+        assert.equal(optInManager.rejectExpiration, customExpiration);
         assert.equal(optInManager.domain, '.test.com');
         assert.equal(optInManager.queryParam, customQueryParam);
     });

--- a/src/OptInManager.js
+++ b/src/OptInManager.js
@@ -1,6 +1,7 @@
 import Cookies from 'js-cookie';
 
 const DEFAULT_ACCEPT_COOKIE_EXPIRATION = 18250; // 50 years in days
+const DEFAULT_REJECT_COOKIE_EXPIRATION = 1;
 export const DEFAULT_QUERY_PARAM_NAME = 'tracking-opt-in-status';
 export const DEFAULT_COOKIE_NAME = 'tracking-opt-in-status';
 export const STATUS = {
@@ -18,9 +19,10 @@ function getCookieDomain(hostname) {
 }
 
 class OptInManager {
-    constructor(hostname, cookieName, expirationInDays, queryParam) {
+    constructor(hostname, cookieName, acceptExpiration, rejectExpiration, queryParam) {
         this.cookieName = cookieName || DEFAULT_COOKIE_NAME;
-        this.expirationInDays = expirationInDays || DEFAULT_ACCEPT_COOKIE_EXPIRATION;
+        this.acceptExpiration = acceptExpiration || DEFAULT_ACCEPT_COOKIE_EXPIRATION;
+        this.rejectExpiration = rejectExpiration || DEFAULT_REJECT_COOKIE_EXPIRATION;
         this.domain = getCookieDomain(hostname || window.location.hostname);
         this.queryParam = queryParam || DEFAULT_QUERY_PARAM_NAME;
     }
@@ -39,7 +41,7 @@ class OptInManager {
 
     setTrackingAccepted() {
         const attributes = {
-            expires: this.expirationInDays,
+            expires: this.acceptExpiration,
         };
 
         if (this.domain) {
@@ -58,7 +60,14 @@ class OptInManager {
     }
 
     setTrackingRejected() {
-        const attributes = this.domain ? { domain: this.domain } : {};
+        const attributes = {
+            expires: this.rejectExpiration,
+        };
+
+        if (this.domain) {
+            attributes.domain = this.domain;
+        }
+
         Cookies.set(this.cookieName, STATUS.REJECTED, attributes);
     }
 

--- a/src/OptInManager.js
+++ b/src/OptInManager.js
@@ -1,7 +1,7 @@
 import Cookies from 'js-cookie';
 
 const DEFAULT_ACCEPT_COOKIE_EXPIRATION = 18250; // 50 years in days
-const DEFAULT_REJECT_COOKIE_EXPIRATION = 1;
+const DEFAULT_REJECT_COOKIE_EXPIRATION = 31;
 export const DEFAULT_QUERY_PARAM_NAME = 'tracking-opt-in-status';
 export const DEFAULT_COOKIE_NAME = 'tracking-opt-in-status';
 export const STATUS = {

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const DEFAULT_OPTIONS = {
     beaconCookieName: null,
     cookieName: null, // use default cookie name
     cookieExpiration: null, // use default
+    cookieRejectExpiration: null,
     country: null, // country code
     countriesRequiringPrompt: null, // array of lower case country codes
     language: null,
@@ -39,6 +40,7 @@ export default function main(options) {
         window.location.hostname,
         depOptions.cookieName,
         depOptions.cookieExpiration,
+        depOptions.cookieRejectExpiration,
         depOptions.queryParamName
     );
     const contentManager = new ContentManager(langManager.lang);


### PR DESCRIPTION
@Wikia/cake 

Sets an expiration time on the rejection cookie so that users aren't prompted on each browser session.