### PR TITLE
CAKE-3193 | Design Updates

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -84,7 +84,7 @@ class App extends Component {
                     </div>
                     <div className={styles.content}>
                         <div className={styles.usesCookiesText}> {content.headline} </div>
-                        <div>
+                        <div className={styles.bodyParagraphsContainer}>
                             {content.bodyParagraphs.map((paragraph) =>
                                 <p>{paragraph}</p>
                             )}

--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -157,3 +157,9 @@ $desktop-devices: "only screen and (min-width: #{$breakpoint})";
     padding-right: 10px;
   }
 }
+
+.bodyParagraphsContainer {
+  p:last-of-type {
+    margin-bottom: 0; // save some space to prevent scroll bars
+  }
+}

--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -67,7 +67,7 @@ $desktop-devices: "only screen and (min-width: #{$breakpoint})";
 }
 
 .content {
-  line-height: 1.43;
+  line-height: 1.43 !important;
   margin-bottom: 20px;
   text-align: center;
   overflow-y: auto;
@@ -112,6 +112,7 @@ $desktop-devices: "only screen and (min-width: #{$breakpoint})";
   color: white;
   font-size: 12px;
   font-weight: bold;
+  line-height: 1;
   padding: 12px 18px;
   text-align: center;
 
@@ -133,6 +134,7 @@ $desktop-devices: "only screen and (min-width: #{$breakpoint})";
   border: none;
   font-size: 12px;
   font-weight: bold;
+  line-height: 1;
   padding: 12px 18px;
   text-align: center;
 
@@ -159,6 +161,12 @@ $desktop-devices: "only screen and (min-width: #{$breakpoint})";
 }
 
 .bodyParagraphsContainer {
+  p {
+    margin-top: 14px;
+    margin-bottom: 14px;
+    line-height: 1.57;
+  }
+
   p:last-of-type {
     margin-bottom: 0; // save some space to prevent scroll bars
   }


### PR DESCRIPTION
Prevent some scrolling by reducing last paragraph size and increase some specificity. 
The source of these style issues are the very generic selectors on upstream. I'm sure I missed some styles but I'm skeptical of the cost-benefit of the time to track down each little specificity issue on a platform with very low traffic. 

@Wikia/cake 