### PR TITLE
Run jenkins tasks on qa executors instead

### DIFF
--- a/release/jenkins
+++ b/release/jenkins
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     node {
-      label 'docker-daemon'
+      label 'qa-executors'
     }
   }
 


### PR DESCRIPTION
The major dependency of this build is nodejs.  Changing nodejs version seems to trigger a g++ build.  g++ is installed on executors, but not docker-builder

so this build might be better suited to qa-executor nodes.