### PR TITLE
Ability to serve from devbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "scripts": {
     "start": "yarn clean && yarn dev",
+    "nohup": "yarn clean && nohup yarn dev &",
     "dev": "cross-env NODE_ENV=development webpack-serve ./webpack.config.js",
     "build": "yarn build:webpack",
     "build:webpack": "cross-env NODE_ENV=production webpack",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ if (process.env.NODE_ENV === 'development') {
     topLevelOptions = {
         serve: {
             port: 3000,
+            host: '0.0.0.0',
             hot: {
                 port: 3001,
             }


### PR DESCRIPTION
Uses host `0.0.0.0` to work on devbox and add `yarn nohup` to make process run in the background

@Wikia/cake 