### PR TITLE
CAKE-5003 Fix disallowed indication when vendor is disallowed

### DIFF
--- a/src/components/PreferencesVendorList.js
+++ b/src/components/PreferencesVendorList.js
@@ -57,7 +57,7 @@ class PreferencesVendorList extends Component {
                             <div className={`${styles.vendorDetail} ${styles.flex}`}>
                                 <span>{getPurposeTitle(content, purposeId)}</span>
                                 <span classname={styles.allowed}>
-                                    {this.isConsentedPurpose(purposeId) ? content.allowedButton : content.disallowedButton}
+                                    {this.isConsentedVendor(vendor.id) && this.isConsentedPurpose(purposeId) ? content.allowedButton : content.disallowedButton}
                                 </span>
                             </div>
                         ))}


### PR DESCRIPTION
This fixes a bug where a vendor shows "allowed" even if it's been disallowed. We need to check both the vendor and purpose to determine if it's allowed.