### PR TITLE
Serve prod alternate method

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
   "scripts": {
     "nohup:dev": "yarn clean && nohup yarn start:dev &",
     "nohup:prod": "yarn clean && nohup yarn start:prod &",
-    "dev": "NODE_ENV=development cross-env webpack-serve ./webpack.config.js",
+    "dev": "NODE_ENV=development SERVE=true cross-env webpack-serve ./webpack.config.js",
     "start:dev": "yarn clean && yarn dev",
-    "start:prod": "NODE_ENV=production cross-env webpack-serve ./webpack.config.js",
+    "start:prod": "NODE_ENV=production SERVE=true cross-env webpack-serve ./webpack.config.js",
     "build": "yarn build:webpack",
     "build:webpack": "cross-env NODE_ENV=production webpack",
     "build:babel": "babel src --out-dir dist/src --ignore index-dev.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,14 +17,20 @@ const autoprefixerPlugin = autoprefixer({
 });
 const isDevelopment = process.env.NODE_ENV === 'development';
 
-module.exports = {
-    serve: {
-        port: 3000,
-        host: '0.0.0.0',
-        hot: {
-            port: 3001,
+let topLevelOptions = {};
+
+if (process.env.NODE_ENV === 'development' || process.env.SERVE) {
+    topLevelOptions = {
+        serve: {
+            port: 3000,
+            hot: {
+                port: 3001,
+            }
         }
-    },
+    };
+}
+
+module.exports = {
     mode: process.env.NODE_ENV,
     entry: isDevelopment ? './src/index.js' : './src/index-dev.js',
     output: {
@@ -90,4 +96,5 @@ module.exports = {
             openAnalyzer: false,
         }),
     ],
+    ...topLevelOptions,
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ const isDevelopment = process.env.NODE_ENV === 'development';
 
 let topLevelOptions = {};
 
-if (process.env.NODE_ENV === 'development' || process.env.SERVE) {
+if (process.env.NODE_ENV === 'development' || process.env.SERVE === 'true') {
     topLevelOptions = {
         serve: {
             port: 3000,


### PR DESCRIPTION
Webpack doesn't like the `serve` option being used in production mode, but we'd still like to use it for testing. So this reverts https://github.com/Wikia/tracking-opt-in/commit/e4ca1732d298c5e685664da1c77110a882b244fe#diff-11e9f7f953edc64ba14b0cc350ae7b9d while adding an environment var check to toggle serving on port 3000.