### PR TITLE
CAKE-5003 Override link color from Fandom Creator communities

### DIFF
--- a/src/components/PreferencesVendorList.scss
+++ b/src/components/PreferencesVendorList.scss
@@ -64,7 +64,7 @@
 }
 
 .link {
-    color: $color-link;
+    color: $color-link !important;
     font-size: 12px;
     font-weight: bold;
     text-decoration: none;


### PR DESCRIPTION
This was already done for other links but was missed in this file.