### PR TITLE
CAKE-5093 Add HTML attribute for testing

### DIFF
--- a/src/components/Preferences.js
+++ b/src/components/Preferences.js
@@ -117,6 +117,7 @@ class Preferences extends Component {
 
         return (
             <div
+                data-tracking-opt-in-overlay="true"
                 className={globalStyles.overlay}
                 style={{
                     zIndex: appOptions.zIndex,


### PR DESCRIPTION
The second screen/overlay was missing a HTML attribute which was used for testing. This adds it back.