### PR TITLE
CAKE-5097 Don't use cutting Edge JS object

### DIFF
--- a/selenium/test.js
+++ b/selenium/test.js
@@ -34,7 +34,7 @@ function setGeoCookie(country) {
 
 // windows needs the geo cookie set to something
 function removeGeoCookie(country) {
-    browser.setCookies({ name: 'Geo', value: '{' });
+    browser.setCookies({ name: 'Geo', value: '{}' });
 }
 
 function ensureUserPrompt() {

--- a/src/GeoManager-test.js
+++ b/src/GeoManager-test.js
@@ -45,7 +45,7 @@ describe('GeoManager', () => {
 
         describe('and unparseable geo cookie', () => {
             it('indicates consent is required', () => {
-                Cookies.set(COUNTRY_COOKIE_NAME, '{');
+                Cookies.set(COUNTRY_COOKIE_NAME, '{}');
                 assert.isNotOk(new GeoManager().needsTrackingPrompt());
             });
         });

--- a/src/LangManager.js
+++ b/src/LangManager.js
@@ -1,12 +1,11 @@
 import { langToContent } from './ContentManager';
+import { getUrlParameter } from './utils';
 
 export const DEFAULT_LANG = 'en';
 export const DEFAULT_BROWSER_LANG = 'en-us';
 
-const urlParams = new URLSearchParams(window.location.search);
-
 // https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/language
-const getBrowserLang = () =>  window.navigator && window.navigator.language
+const getBrowserLang = () => (window.navigator && window.navigator.language)
     ? window.navigator.language : DEFAULT_BROWSER_LANG;
 
 // parse the browser lang to map to just a two letter lang code or 'zh-hans'/'zh-hant'
@@ -21,7 +20,7 @@ const browserLangToLang = (browserLang) => {
 
 export default class LangManager {
     constructor(browserLang) {
-        this.browserLang = (urlParams.get('uselang') || browserLang || getBrowserLang()).toLowerCase();
+        this.browserLang = (getUrlParameter('uselang') || browserLang || getBrowserLang()).toLowerCase();
         this.lang = browserLangToLang(this.browserLang);
     }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,6 +34,20 @@ export function isParameterSet(param) {
     return window.location.href.indexOf(`${param}=true`) !== -1;
 }
 
+export function getUrlParameter(paramName) {
+    const paramList = window.location.search.slice(1).split('&');
+    paramList.forEach((param) => {
+        if (param.length > 0) {
+            const keyValue = param.split('=');
+            if (keyValue[0] === paramName) {
+                // May return undefined
+                return keyValue[1];
+            }
+        }
+    });
+    return null;
+};
+
 export function parseUrl(url) {
     const parser = document.createElement('a');
     parser.href = url;

--- a/src/utils.js
+++ b/src/utils.js
@@ -36,16 +36,17 @@ export function isParameterSet(param) {
 
 export function getUrlParameter(paramName) {
     const paramList = window.location.search.slice(1).split('&');
+    let paramValue = null;
     paramList.forEach((param) => {
         if (param.length > 0) {
             const keyValue = param.split('=');
             if (keyValue[0] === paramName) {
                 // May return undefined
-                return keyValue[1];
+                paramValue = keyValue[1];
             }
         }
     });
-    return null;
+    return paramValue;
 };
 
 export function parseUrl(url) {


### PR DESCRIPTION
Replaces an object not supported by IE11. The `isParameterSet` function could instead use the same method, but I couldn't get window.location mocking to work that way for the mobile app unit test.