### PR TITLE
CAKE-5105 Fix cookie domain for .co.uk (and others)

### DIFF
--- a/src/utils-test.js
+++ b/src/utils-test.js
@@ -38,6 +38,16 @@ describe('Utils', () => {
 
             assert.equal(domain, '.fandom.com');
         });
+
+        it('handles .co country-code domains', () => {
+            let domain = utils.getCookieDomain('somethingbritish.co.uk');
+
+            assert.equal(domain, '.somethingbritish.co.uk');
+
+            domain = utils.getCookieDomain('somethingkiwi.co.nz');
+
+            assert.equal(domain, '.somethingkiwi.co.nz');
+        });
     });
 
     context('getJSON', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,7 +61,20 @@ export function getCookieDomain(hostname) {
         return undefined;
     }
 
-    return `.${parts[parts.length - 2]}.${parts[parts.length - 1]}`;
+    let cookieDomain = `.${parts[parts.length - 2]}.${parts[parts.length - 1]}`;
+    // These exceptions require a third part for a valid cookie domain. This isn't
+    // a definitive list but rather the most likely domains on which Fandom would
+    // host a site.
+    const exceptions = [
+        '.co.jp',
+        '.co.nz',
+        '.co.uk',
+    ];
+    if (exceptions.indexOf(cookieDomain) >= 0) {
+        cookieDomain = `.${parts[parts.length - 3]}${cookieDomain}`;
+    }
+
+    return cookieDomain;
 }
 
 const cachedJson = {};


### PR DESCRIPTION
This fixes an issue where we were attempting to set a cookie on the co.uk SLD rather than the proper full domain (eg. fm-base.co.uk).