### PR TITLE
CAKE-5110 Make styling compatible with IE 11

### DIFF
--- a/src/components/Preferences.scss
+++ b/src/components/Preferences.scss
@@ -11,9 +11,10 @@
 
     @media #{$desktop-devices} {
         height: 600px;
+        left: 50%;
         max-height: 90vh;
         top: 50%;
-        transform: translateY(-50%);
+        transform: translate(-50%, -50%);
         max-width: 768px;
     }
 }

--- a/src/components/ScreenOne.scss
+++ b/src/components/ScreenOne.scss
@@ -1,13 +1,15 @@
 @import "./consts.scss";
 
 .dialog {
+    bottom: 0px;
     display: flex;
     flex-direction: column;
+    position: fixed;
+    width: 100vw;
 
     @media #{$mobile-devices} {
         max-height: calc(100vh - 55px);
         position: absolute;
-        width: 100vw;
     }
 }
 

--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -5,13 +5,11 @@
 }
 
 .overlay {
-    align-items: flex-end;
     background-color: rgba(0, 0, 0, .5);
     bottom: 0;
     color: $color-text;
-    display: flex;
-    justify-content: center;
     left: 0;
+    max-width: 100vw;
     position: fixed;
     right: 0;
     top: 0;
@@ -36,6 +34,7 @@
     box-shadow: 0 0 6px 0 rgba(195, 195, 195, 0.5);
     box-sizing: border-box;
     height: 60px;
+    min-height: 60px;
     padding: 12px 27px;
     text-align: center;
 


### PR DESCRIPTION
Tested in IE 11 on Windows 10, and checked for backward-compatibility in Chromium.