### PR TITLE
ADEN-10225 Remove euconsent-v2 cookie if GVL tcfPolicyVersion changes.

### DIFF
--- a/src/gdpr/TrackingOptIn.js
+++ b/src/gdpr/TrackingOptIn.js
@@ -240,62 +240,69 @@ class TrackingOptIn {
             return;
         }
 
-        if (!this.needsTCF2Consent() || isParameterSet('mobile-app')) {
-            this.consentManagementProvider.run();
-            return;
-        }
+        this.consentManagementProvider.loadVendorList()
+            .then(() => {
+                if (this.consentManagementProvider.isVendorTCFPolicyVersionOutdated()) {
+                    this.consentManagementProvider.setVendorConsentCookie(null);
+                }
 
-        if (allowedVendors !== undefined || allowedPurposes !== undefined) {
-            this.consentManagementProvider.updateApi(API_STATUS.DISABLED);
-            return;
-        }
+                if (!this.needsTCF2Consent() || isParameterSet('mobile-app')) {
+                    this.consentManagementProvider.run();
+                    return;
+                }
 
-        if (!this.root) {
-            this.root = document.createElement('div');
-            document.body.appendChild(this.root);
-        }
+                if (allowedVendors !== undefined || allowedPurposes !== undefined) {
+                    this.consentManagementProvider.updateApi(API_STATUS.DISABLED);
+                    return;
+                }
 
-        const options = {
-            // ToDo: get rid of hardcoded list of purposes during cleanup
-            enabledPurposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-            enabledVendors: this.options.enabledVendors,
-            zIndex: this.options.zIndex,
-            preventScrollOn: this.options.preventScrollOn,
-            isCurse: this.options.isCurse,
-        };
+                if (!this.root) {
+                    this.root = document.createElement('div');
+                    document.body.appendChild(this.root);
+                }
 
-        this.consentManagementProvider.updateApi(API_STATUS.UI_VISIBLE_NEW);
+                const options = {
+                    // ToDo: get rid of hardcoded list of purposes during cleanup
+                    enabledPurposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                    enabledVendors: this.options.enabledVendors,
+                    zIndex: this.options.zIndex,
+                    preventScrollOn: this.options.preventScrollOn,
+                    isCurse: this.options.isCurse,
+                };
 
-        render(
-            <Modal
-                onRequestAppRemove={this.removeApp}
-                onAcceptTracking={(allowedVendors, allowedPurposes) => {
-                    this.consentManagementProvider.configure({
-                        allowedVendors: allowedVendors,
-                        allowedVendorPurposes: allowedPurposes
-                    });
-                    this.consentManagementProvider.run().then(() => {
-                        this.options.onAcceptTracking(allowedVendors, allowedPurposes);
-                    });
-                }}
-                onRejectTracking={(allowedVendors, allowedPurposes) => {
-                    this.consentManagementProvider.configure({
-                        allowedVendors: allowedVendors,
-                        allowedVendorPurposes: allowedPurposes
-                    });
-                    this.consentManagementProvider.run().then(() => {
-                        this.options.onRejectTracking(allowedVendors, allowedPurposes);
-                    });
-                }}
-                tracker={this.tracker}
-                optInManager={this.optInManager}
-                geoManager={this.geoManager}
-                options={options}
-                content={this.contentManager.content}
-            />,
-            this.root,
-            this.root.lastChild
-        );
+                this.consentManagementProvider.updateApi(API_STATUS.UI_VISIBLE_NEW);
+
+                render(
+                    <Modal
+                        onRequestAppRemove={this.removeApp}
+                        onAcceptTracking={(allowedVendors, allowedPurposes) => {
+                            this.consentManagementProvider.configure({
+                                allowedVendors: allowedVendors,
+                                allowedVendorPurposes: allowedPurposes
+                            });
+                            this.consentManagementProvider.run().then(() => {
+                                this.options.onAcceptTracking(allowedVendors, allowedPurposes);
+                            });
+                        }}
+                        onRejectTracking={(allowedVendors, allowedPurposes) => {
+                            this.consentManagementProvider.configure({
+                                allowedVendors: allowedVendors,
+                                allowedVendorPurposes: allowedPurposes
+                            });
+                            this.consentManagementProvider.run().then(() => {
+                                this.options.onRejectTracking(allowedVendors, allowedPurposes);
+                            });
+                        }}
+                        tracker={this.tracker}
+                        optInManager={this.optInManager}
+                        geoManager={this.geoManager}
+                        options={options}
+                        content={this.contentManager.content}
+                    />,
+                    this.root,
+                    this.root.lastChild
+                );
+            });
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -77,8 +77,6 @@ function initializeGDPR(options) {
 
     if (optInManager.checkCookieVersion()) {
         consentManagementProviderLegacy.setVendorConsentCookie(null);
-        // ToDo: add additional reset if GVL will change
-        consentManagementProvider.setVendorConsentCookie(null);
     }
 
     const instance = new TrackingOptIn(


### PR DESCRIPTION
Move body of gatherTCF2Consent method into a Promise body,
which is resolved once vendor-list.json is fetched.

The vendor-list.json is cached for a week so we're safe
to postpone execution until it's downloaded.