### PR TITLE
ADEN-13021 - Changed button order on mobile

### DIFF
--- a/src/modal/ScreenOne.js
+++ b/src/modal/ScreenOne.js
@@ -43,21 +43,23 @@ class ScreenOne extends Component {
                         >
                             {content.learnMoreButton}
                         </div>
-                        <div
-                            data-tracking-opt-in-accept="true"
-                            className={`${globalStyles.acceptButton} ${globalStyles.footerButton}`}
-                            onClick={clickAccept}
-                            key="accept"
-                        >
-                            {content.acceptButton}
-                        </div>
-                        <div
-                            data-tracking-opt-in-reject="true"
-                            className={`${globalStyles.rejectButton} ${globalStyles.footerButton}`}
-                            onClick={clickReject}
-                            key="reject"
-                        >
-                            {content.rejectButton}
+                        <div className={globalStyles.consentButtons}>
+                            <div
+                                data-tracking-opt-in-accept="true"
+                                className={`${globalStyles.acceptButton} ${globalStyles.footerButton}`}
+                                onClick={clickAccept}
+                                key="accept"
+                            >
+                                {content.acceptButton}
+                            </div>
+                            <div
+                                data-tracking-opt-in-reject="true"
+                                className={`${globalStyles.rejectButton} ${globalStyles.footerButton}`}
+                                onClick={clickReject}
+                                key="reject"
+                            >
+                                {content.rejectButton}
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/modal/styles.scss
+++ b/src/modal/styles.scss
@@ -36,11 +36,11 @@
     padding: 12px 27px;
     text-align: center;
     display: flex;
-    justify-content: flex-end;
     gap: 16px;
 
     @media #{$desktop-devices} {
         text-align: right;
+        flex-direction: row-reverse;
     }
 
     @media #{$mobile-devices} {
@@ -62,13 +62,17 @@
     outline: none;
     padding: 11px 18px;
     text-transform: uppercase;
+}
 
-    &:first-child,
-    &:nth-child(2) {
-        margin-right: 18px;
-        @media #{$mobile-devices} {
-            margin-right: 0;
-        }
+.consentButtons {
+    display: flex;
+    height: auto;
+    gap: 18px;
+    flex-direction: row-reverse;
+
+    @media #{$mobile-devices} {
+        flex-direction: column-reverse;
+        gap: 8px
     }
 }
 
@@ -85,6 +89,18 @@
     background-color: $color-secondary-fill;
     border: 1px solid $color-secondary;
     color: $color-secondary;
+}
+
+.learnMoreButton {
+    order: 2
+}
+
+.backButton {
+    order: 3
+}
+
+.acceptButton {
+    order: 1
 }
 
 .link {


### PR DESCRIPTION
In this PR I've changed button order on mobile. To do so I had to slightly modify structure of GDPR modal footer and add a few styles. I decided to refator it into Flexbox as it is the most popular and easiest way to arrange items in containers.  
<img width="457" alt="Screenshot 2023-04-06 at 13 34 17" src="https://user-images.githubusercontent.com/6935667/230365291-1d6d5864-4f06-4cef-ae30-2136f0ee8619.png">


<img width="1214" alt="Screenshot 2023-04-06 at 13 34 47" src="https://user-images.githubusercontent.com/6935667/230365193-5ee53dd5-9d8e-43ce-bbba-e6c3af85e7db.png">