### PR TITLE
TACO-269 - Added blocked purposes filtering

### DIFF
--- a/src/gdpr/ConsentManagementProvider.js
+++ b/src/gdpr/ConsentManagementProvider.js
@@ -22,6 +22,7 @@ const PROVIDER_CONSENT_COOKIE_NAME = 'addtl_consent';
 const VENDOR_LIST_URL_BASE = 'https://script.wikia.nocookie.net/fandom-ae-assets/tcf/v2.2/';
 const VENDOR_LIST_FILE_NAME = 'vendor-list.json';
 const VENDOR_LIST_VERSION_NAME = 'archives/vendor-list-v[VERSION].json';
+const BLOCKED_INTERESTS = [1,3,4,5,6];
 const getDefaultCookieAttributes = () => ({
     domain: getCookieDomain(window.location.hostname),
     expires: 390 // thirteen 30-day months
@@ -216,6 +217,10 @@ class ConsentManagementProvider {
         });
     }
 
+    getLegitimateInterests(allowedVendorPurposes) {
+        return Array.isArray(allowedVendorPurposes) ? allowedVendorPurposes.filter(purpose => !BLOCKED_INTERESTS.includes(purpose)) : [];
+    }
+
     createConsent() {
         let acString = this.getProviderConsentCookie();
         let tcString = this.getDeprecatedVendorConsentCookie();
@@ -240,7 +245,7 @@ class ConsentManagementProvider {
         tcModel.specialFeatureOptins.set(Array.isArray(allowedSpecialFeatures) ? allowedSpecialFeatures : []);
         tcModel.vendorConsents.set(Array.isArray(allowedVendors) ? allowedVendors : []);
         // ToDo: proper implementation of Right to Object
-        tcModel.purposeLegitimateInterests.set(Array.isArray(allowedVendorPurposes) ? allowedVendorPurposes : []);
+        tcModel.purposeLegitimateInterests.set(this.getLegitimateInterests(allowedVendorPurposes));
         tcModel.vendorLegitimateInterests.set(Array.isArray(allowedVendors) ? allowedVendors : []);
 
         debug('GDPR', 'Consent saved with vendors: ', allowedVendors, ' and purposes', allowedVendorPurposes, ' and special feature options', allowedSpecialFeatures, ' and providers', allowedProviders);


### PR DESCRIPTION
In this PR I've added Legitimate Interests filtering. Since TCF 2.2 some Legitimate Interests should be blocked, and TCF strings, containing these interests are being recognized as invalid by Pubmatic. I've modified our logic to get only these interests, that are not blocked.