### PR TITLE
TACO-390 Update privacy string for kid users

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import UserSignalMechanism from './ccpa/UserSignalMechanism';
 import { communicationService } from './shared/communication';
 import { debug } from './shared/utils';
 import { oneTrust } from './onetrust';
+import Cookies from 'js-cookie';
 
 export const DEFAULT_OPTIONS = {
     sessionCookies: SESSION_COOKIES, // array of sessionCookies with extension times
@@ -38,7 +39,21 @@ export const DEFAULT_CCPA_OPTIONS = {
     countriesRequiringPrompt: ['us'], // array of lower case country codes
     isSubjectToCcpa: window && window.ads && window.ads.context && window.ads.context.opts
                      && window.ads.context.opts.isSubjectToCcpa,
+    isSubjectToCoppa: isSubjectToCoppa(),
 };
+
+function isSubjectToCoppa() {
+    const wikiDirectedAtChildren = window.ads && window.ads.context && window.ads.context.targeting
+        && window.ads.context.targeting.directedAtChildren;
+
+    if (!wikiDirectedAtChildren) {
+        return false;
+    }
+
+    const ageGateCookie = Cookies.get('ag');
+
+    return ageGateCookie && ageGateCookie === '0'; // '0' means user is a kid
+}
 
 function initializeGDPR(options) {
     const depOptions = Object.assign({}, DEFAULT_OPTIONS, options);


### PR DESCRIPTION
### Ticket
https://fandom.atlassian.net/browse/TACO-390

### Description
Currently in US when user clicks "I am a kid" in Age Gate modal, the `usprivacy` cookie stays at the value `1YNN` which means - NO opt out.

In this PR I fixed this issue, so when user is on wiki directed at children, and he clicks "I am a kid", the `usprivacy`cookie is updated to `1YYN` which means opt out.